### PR TITLE
Make text overlay backgrounds transparent

### DIFF
--- a/app/components/PdfEditor.tsx
+++ b/app/components/PdfEditor.tsx
@@ -266,7 +266,7 @@ export default function PdfEditor() {
                           cancel="input,textarea,select,button"
                         >
                           <div className="absolute">
-                            <div className="group rounded px-2 py-1 bg-yellow-100 border border-yellow-300 shadow cursor-move">
+                            <div className="group rounded px-2 py-1 bg-transparent border border-transparent hover:border-slate-300 cursor-move">
                               <input
                                 className="bg-transparent outline-none text-gray-900"
                                 value={o.text}


### PR DESCRIPTION
Make text overlays transparent to improve visibility of PDF content.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ef79ddd-8857-4a7e-8d7d-8771cb179a8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ef79ddd-8857-4a7e-8d7d-8771cb179a8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

