### PR TITLE
Fix exported pdf text alignment

### DIFF
--- a/app/components/PdfEditor.tsx
+++ b/app/components/PdfEditor.tsx
@@ -225,7 +225,8 @@ export default function PdfEditor() {
           const textWidth = font.widthOfTextAtSize(o.text, o.fontSize);
           const xPdf = o.x * pageWidth;
           const yTop = o.y * pageHeight; // normalized from top
-          const yPdf = pageHeight - yTop - o.fontSize; // convert top-origin to bottom-origin
+          const ascent = getFontAscentAtSize(font, o.fontSize);
+          const yPdf = pageHeight - yTop - ascent; // convert top-origin to baseline-origin
           page.drawText(o.text, {
             x: xPdf,
             y: yPdf,
@@ -263,6 +264,22 @@ export default function PdfEditor() {
     const g = Math.min(255, Math.max(0, parseInt(m[2], 10)));
     const b = Math.min(255, Math.max(0, parseInt(m[3], 10)));
     return [r / 255, g / 255, b / 255];
+  }
+
+  function getFontAscentAtSize(font: any, size: number): number {
+    try {
+      if (font && typeof font.ascentAtSize === 'function') {
+        const v = font.ascentAtSize(size);
+        if (typeof v === 'number' && isFinite(v)) return v;
+      }
+    } catch {}
+    try {
+      if (font && typeof font.heightAtSize === 'function') {
+        const h = font.heightAtSize(size);
+        if (typeof h === 'number' && isFinite(h)) return h * 0.8; // approximate ascent proportion
+      }
+    } catch {}
+    return size * 0.8; // safe fallback
   }
 
   return (


### PR DESCRIPTION
Correct text vertical positioning in exported PDFs by using font ascent for baseline alignment.

---
<a href="https://cursor.com/background-agent?bcId=bc-18b8146b-00fa-44d8-bd38-a2ec35f7fbea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-18b8146b-00fa-44d8-bd38-a2ec35f7fbea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

